### PR TITLE
Uploading Task 3

### DIFF
--- a/P2_Assignments/P2_Assignments.sln
+++ b/P2_Assignments/P2_Assignments.sln
@@ -1,11 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36915.13 d17.14
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11505.172 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchoolEntities", "Homework_1\SchoolEntities.csproj", "{879AC7FA-3232-4FA9-82F0-99153724DEFE}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarAtlas.API", "StarAtlas.API\StarAtlas.API.csproj", "{269AE11D-7631-D5AD-75BE-81C8D390D951}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarAtlas.Domain", "StarAtlas.Domain\StarAtlas.Domain.csproj", "{5B120B35-9470-4728-B288-43DA0BCE1BB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarAtlas.Persistence", "StarAtlas.Persistence\StarAtlas.Persistence.csproj", "{F020EB13-CFD3-4D14-A65A-F06AF11DE53D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarAtlas.Infrastructure", "StarAtlas.Infrastructure\StarAtlas.Infrastructure.csproj", "{B58A1D96-F0F7-4DD5-8745-6364B079936B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +17,22 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{879AC7FA-3232-4FA9-82F0-99153724DEFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{879AC7FA-3232-4FA9-82F0-99153724DEFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{879AC7FA-3232-4FA9-82F0-99153724DEFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{879AC7FA-3232-4FA9-82F0-99153724DEFE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{269AE11D-7631-D5AD-75BE-81C8D390D951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{269AE11D-7631-D5AD-75BE-81C8D390D951}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{269AE11D-7631-D5AD-75BE-81C8D390D951}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{269AE11D-7631-D5AD-75BE-81C8D390D951}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B120B35-9470-4728-B288-43DA0BCE1BB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B120B35-9470-4728-B288-43DA0BCE1BB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B120B35-9470-4728-B288-43DA0BCE1BB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B120B35-9470-4728-B288-43DA0BCE1BB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F020EB13-CFD3-4D14-A65A-F06AF11DE53D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F020EB13-CFD3-4D14-A65A-F06AF11DE53D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F020EB13-CFD3-4D14-A65A-F06AF11DE53D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F020EB13-CFD3-4D14-A65A-F06AF11DE53D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B58A1D96-F0F7-4DD5-8745-6364B079936B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B58A1D96-F0F7-4DD5-8745-6364B079936B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B58A1D96-F0F7-4DD5-8745-6364B079936B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B58A1D96-F0F7-4DD5-8745-6364B079936B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/P2_Assignments/StarAtlas.API/Controllers/BodyTypesController.cs
+++ b/P2_Assignments/StarAtlas.API/Controllers/BodyTypesController.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using StarAtlas.API.Data;
-using StarAtlas.API.Models.Entities;
 using StarAtlas.API.Models.Dtos;
+using StarAtlas.Domain.Entities;
+using StarAtlas.Infrastructure.Repositories;
 
 namespace StarAtlas.API.Controllers
 {
@@ -10,17 +10,17 @@ namespace StarAtlas.API.Controllers
     [ApiController]
     public class BodyTypesController : ControllerBase
     {
-        private readonly StarAtlasContext _context;
+        private readonly UnitOfWork _unitOfWork;
 
-        public BodyTypesController(StarAtlasContext context)
+        public BodyTypesController(UnitOfWork unitOfWork)
         {
-            _context = context;
+            _unitOfWork = unitOfWork;
         }
 
         [HttpGet]
         public async Task<ActionResult<IEnumerable<BodyTypeDto>>> GetBodyTypes()
         {
-            var types = await _context.BodyTypes.ToListAsync();
+            var types = await _unitOfWork.BodyTypeRepository.GetAllAsync();
 
             var dtos = types.Select(t => new BodyTypeDto
             {
@@ -34,35 +34,27 @@ namespace StarAtlas.API.Controllers
         [HttpPost]
         public async Task<ActionResult<BodyType>> PostBodyType(BodyType bodyType)
         {
-            _context.BodyTypes.Add(bodyType);
-            await _context.SaveChangesAsync();
+            await _unitOfWork.BodyTypeRepository.AddAsync(bodyType);
+            await _unitOfWork.CompleteAsync();
             return CreatedAtAction("GetBodyTypes", new { id = bodyType.Id }, bodyType);
         }
 
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateBodyType(int id, BodyType bodyType)
         {
-            if (id != bodyType.Id)
-            {
-                return BadRequest("The ID does not match the ID in the body.");
-            }
+            if (id != bodyType.Id) return BadRequest("The ID does not match the ID in the body.");
 
-            _context.Entry(bodyType).State = EntityState.Modified;
+            _unitOfWork.BodyTypeRepository.Update(bodyType);
 
             try
             {
-                await _context.SaveChangesAsync();
+                await _unitOfWork.CompleteAsync();
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!BodyTypeExists(id))
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    throw;
-                }
+                var exists = await _unitOfWork.BodyTypeRepository.GetByIdAsync(id) != null;
+                if (!exists) return NotFound();
+                else throw;
             }
 
             return NoContent();
@@ -71,27 +63,18 @@ namespace StarAtlas.API.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteBodyType(int id)
         {
-            var bodyType = await _context.BodyTypes.FindAsync(id);
-            if (bodyType == null)
-            {
-                return NotFound();
-            }
+            var bodyType = await _unitOfWork.BodyTypeRepository.GetByIdAsync(id);
+            if (bodyType == null) return NotFound();
 
-            var isUsed = await _context.CelestialBodies.AnyAsync(c => c.BodyTypeId == id);
-            if (isUsed)
-            {
-                return BadRequest("Cannot delete this type because it is assigned to existing Celestial Bodies. Delete the stars first.");
-            }
+            var allBodies = await _unitOfWork.CelestialBodyRepository.GetAllAsync();
+            var isUsed = allBodies.Any(c => c.BodyTypeId == id);
 
-            _context.BodyTypes.Remove(bodyType);
-            await _context.SaveChangesAsync();
+            if (isUsed) return BadRequest("Cannot delete this type because it is assigned to existing Celestial Bodies. Delete the stars first.");
+
+            _unitOfWork.BodyTypeRepository.Delete(bodyType);
+            await _unitOfWork.CompleteAsync();
 
             return NoContent();
-        }
-
-        private bool BodyTypeExists(int id)
-        {
-            return _context.BodyTypes.Any(e => e.Id == id);
         }
     }
 }

--- a/P2_Assignments/StarAtlas.API/Controllers/CelestialBodiesController.cs
+++ b/P2_Assignments/StarAtlas.API/Controllers/CelestialBodiesController.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using StarAtlas.API.Data;
-using StarAtlas.API.Models.Entities;
 using StarAtlas.API.Models.Dtos;
+using StarAtlas.Domain.Entities;
+using StarAtlas.Infrastructure.Repositories;
 
 namespace StarAtlas.API.Controllers
 {
@@ -10,26 +10,19 @@ namespace StarAtlas.API.Controllers
     [ApiController]
     public class CelestialBodiesController : ControllerBase
     {
-        private readonly StarAtlasContext _context;
+        private readonly UnitOfWork _unitOfWork;
 
-        public CelestialBodiesController(StarAtlasContext context)
+        public CelestialBodiesController(UnitOfWork unitOfWork)
         {
-            _context = context;
+            _unitOfWork = unitOfWork;
         }
-
-
 
         [HttpGet("{id}")]
         public async Task<ActionResult<CelestialBodyDto>> GetCelestialBody(int id)
         {
-            var body = await _context.CelestialBodies
-                                     .Include(c => c.BodyType)
-                                     .FirstOrDefaultAsync(b => b.Id == id);
+            var body = await _unitOfWork.CelestialBodyRepository.GetByIdWithTypeAsync(id);
 
-            if (body == null)
-            {
-                return NotFound();
-            }
+            if (body == null) return NotFound();
 
             var dto = new CelestialBodyDto
             {
@@ -54,8 +47,8 @@ namespace StarAtlas.API.Controllers
                 BodyTypeId = dto.BodyTypeId
             };
 
-            _context.CelestialBodies.Add(celestialBody);
-            await _context.SaveChangesAsync();
+            await _unitOfWork.CelestialBodyRepository.AddAsync(celestialBody);
+            await _unitOfWork.CompleteAsync();
 
             return CreatedAtAction("GetCelestialBody", new { id = celestialBody.Id }, celestialBody);
         }
@@ -63,16 +56,10 @@ namespace StarAtlas.API.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateCelestialBody(int id, UpdateCelestialBodyDto dto)
         {
-            if (id != dto.Id)
-            {
-                return BadRequest("El ID de la URL no coincide con el ID del cuerpo del mensaje.");
-            }
+            if (id != dto.Id) return BadRequest("El ID de la URL no coincide con el ID del cuerpo del mensaje.");
 
-            var existingBody = await _context.CelestialBodies.FindAsync(id);
-            if (existingBody == null)
-            {
-                return NotFound($"No se encontró el astro con ID {id}");
-            }
+            var existingBody = await _unitOfWork.CelestialBodyRepository.GetByIdAsync(id);
+            if (existingBody == null) return NotFound($"No se encontró el astro con ID {id}");
 
             existingBody.Name = dto.Name;
             existingBody.Description = dto.Description;
@@ -80,37 +67,27 @@ namespace StarAtlas.API.Controllers
             existingBody.DiscoveryDate = dto.DiscoveryDate;
             existingBody.BodyTypeId = dto.BodyTypeId;
 
+            _unitOfWork.CelestialBodyRepository.Update(existingBody);
+
             try
             {
-                await _context.SaveChangesAsync();
+                await _unitOfWork.CompleteAsync();
             }
-            catch (DbUpdateConcurrencyException)
-            {
-                throw;
-            }
+            catch (DbUpdateConcurrencyException) { throw; }
 
             return NoContent();
         }
 
-
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteCelestialBody(int id)
         {
-            var celestialBody = await _context.CelestialBodies.FindAsync(id);
-            if (celestialBody == null)
-            {
-                return NotFound($"Celestial Body with ID {id} not found.");
-            }
+            var celestialBody = await _unitOfWork.CelestialBodyRepository.GetByIdAsync(id);
+            if (celestialBody == null) return NotFound($"Celestial Body with ID {id} not found.");
 
-            _context.CelestialBodies.Remove(celestialBody);
-            await _context.SaveChangesAsync();
+            _unitOfWork.CelestialBodyRepository.Delete(celestialBody);
+            await _unitOfWork.CompleteAsync();
 
-            return NoContent(); 
-        }
-
-        private bool CelestialBodyExists(int id)
-        {
-            return _context.CelestialBodies.Any(e => e.Id == id);
+            return NoContent();
         }
     }
 }

--- a/P2_Assignments/StarAtlas.API/Controllers/ObservationsController.cs
+++ b/P2_Assignments/StarAtlas.API/Controllers/ObservationsController.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using StarAtlas.API.Data;
-using StarAtlas.API.Models.Entities;
 using StarAtlas.API.Models.Dtos;
+using StarAtlas.Domain.Entities;
+using StarAtlas.Infrastructure.Repositories;
 
 namespace StarAtlas.API.Controllers
 {
@@ -10,46 +10,37 @@ namespace StarAtlas.API.Controllers
     [ApiController]
     public class ObservationsController : ControllerBase
     {
-        private readonly StarAtlasContext _context;
+        private readonly UnitOfWork _unitOfWork;
 
-        public ObservationsController(StarAtlasContext context)
+        public ObservationsController(UnitOfWork unitOfWork)
         {
-            _context = context;
+            _unitOfWork = unitOfWork;
         }
 
         [HttpGet("star/{celestialBodyId}")]
         public async Task<ActionResult<IEnumerable<ObservationDto>>> GetObservationsByBody(int celestialBodyId)
         {
-            var observations = await _context.Observations
-                                             .Include(o => o.CelestialBody) 
-                                             .Where(o => o.CelestialBodyId == celestialBodyId)
-                                             .OrderByDescending(o => o.ObservationDate) 
-                                             .Select(o => new ObservationDto
-                                             {
-                                                 Id = o.Id,
-                                                 Date = o.ObservationDate,
-                                                 Location = o.Location ?? "Unknown", 
-                                                 Note = o.PersonalNote,
-                                                 CelestialBodyName = o.CelestialBody != null ? o.CelestialBody.Name : "Unknown"
-                                             })
-                                             .ToListAsync();
+            var observations = await _unitOfWork.ObservationRepository.GetObservationsByStarAsync(celestialBodyId);
 
-            if (!observations.Any())
+            if (!observations.Any()) return NotFound("No observations found for this celestial body.");
+
+            var dtos = observations.Select(o => new ObservationDto
             {
-                return NotFound("No observations found for this celestial body.");
-            }
+                Id = o.Id,
+                Date = o.ObservationDate,
+                Location = o.Location ?? "Unknown",
+                Note = o.PersonalNote,
+                CelestialBodyName = o.CelestialBody != null ? o.CelestialBody.Name : "Unknown"
+            }).ToList();
 
-            return Ok(observations);
+            return Ok(dtos);
         }
 
         [HttpPost]
         public async Task<ActionResult<ObservationDto>> CreateObservation(CreateObservationDto dto)
         {
-            var bodyExists = await _context.CelestialBodies.AnyAsync(b => b.Id == dto.CelestialBodyId);
-            if (!bodyExists)
-            {
-                return BadRequest("Celestial Body ID not found.");
-            }
+            var existingBody = await _unitOfWork.CelestialBodyRepository.GetByIdAsync(dto.CelestialBodyId);
+            if (existingBody == null) return BadRequest("Celestial Body ID not found.");
 
             var observation = new Observation
             {
@@ -59,8 +50,8 @@ namespace StarAtlas.API.Controllers
                 ObservationDate = DateTime.Now
             };
 
-            _context.Observations.Add(observation);
-            await _context.SaveChangesAsync();
+            await _unitOfWork.ObservationRepository.AddAsync(observation);
+            await _unitOfWork.CompleteAsync();
 
             return CreatedAtAction(nameof(GetObservationsByBody),
                 new { celestialBodyId = observation.CelestialBodyId },
@@ -70,41 +61,33 @@ namespace StarAtlas.API.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateObservation(int id, [FromBody] CreateObservationDto dto)
         {
-            var existingObservation = await _context.Observations.FindAsync(id);
+            var existingObservation = await _unitOfWork.ObservationRepository.GetByIdAsync(id);
 
-            if (existingObservation == null)
-            {
-                return NotFound("Observation not found.");
-            }
+            if (existingObservation == null) return NotFound("Observation not found.");
 
             existingObservation.PersonalNote = dto.PersonalNote;
             existingObservation.Location = dto.Location;
             existingObservation.ObservationDate = DateTime.Now;
 
+            _unitOfWork.ObservationRepository.Update(existingObservation);
+
             try
             {
-                await _context.SaveChangesAsync();
+                await _unitOfWork.CompleteAsync();
             }
-            catch (DbUpdateConcurrencyException)
-            {
-                throw; 
-            }
+            catch (DbUpdateConcurrencyException) { throw; }
 
             return NoContent();
         }
 
-
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteObservation(int id)
         {
-            var observation = await _context.Observations.FindAsync(id);
-            if (observation == null)
-            {
-                return NotFound("Observation not found.");
-            }
+            var observation = await _unitOfWork.ObservationRepository.GetByIdAsync(id);
+            if (observation == null) return NotFound("Observation not found.");
 
-            _context.Observations.Remove(observation);
-            await _context.SaveChangesAsync();
+            _unitOfWork.ObservationRepository.Delete(observation);
+            await _unitOfWork.CompleteAsync();
 
             return NoContent();
         }

--- a/P2_Assignments/StarAtlas.API/Program.cs
+++ b/P2_Assignments/StarAtlas.API/Program.cs
@@ -1,15 +1,13 @@
 using Microsoft.EntityFrameworkCore;
-using StarAtlas.API.Data;
+using StarAtlas.Persistence.Context;
+using StarAtlas.Infrastructure.Repositories; 
 
 var builder = WebApplication.CreateBuilder(args);
 
-
 builder.Services.AddControllers();
-
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 
@@ -17,8 +15,16 @@ builder.Services.AddDbContext<StarAtlasContext>(options =>
     options.UseSqlServer(connectionString));
 
 
-var app = builder.Build();
+builder.Services.AddTransient(typeof(GenericRepository<>));
 
+builder.Services.AddTransient<CelestialBodyRepository>();
+builder.Services.AddTransient<BodyTypeRepository>();
+builder.Services.AddTransient<ObservationRepository>();
+
+builder.Services.AddTransient<UnitOfWork>();
+
+
+var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/P2_Assignments/StarAtlas.API/StarAtlas.API.csproj
+++ b/P2_Assignments/StarAtlas.API/StarAtlas.API.csproj
@@ -8,19 +8,19 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StarAtlas.Domain\StarAtlas.Domain.csproj" />
+    <ProjectReference Include="..\StarAtlas.Infrastructure\StarAtlas.Infrastructure.csproj" />
+    <ProjectReference Include="..\StarAtlas.Persistence\StarAtlas.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/P2_Assignments/StarAtlas.Domain/Entities/BodyType.cs
+++ b/P2_Assignments/StarAtlas.Domain/Entities/BodyType.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StarAtlas.API.Models.Entities 
+namespace StarAtlas.Domain.Entities
 {
     public class BodyType
     {

--- a/P2_Assignments/StarAtlas.Domain/Entities/CelestialBody.cs
+++ b/P2_Assignments/StarAtlas.Domain/Entities/CelestialBody.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace StarAtlas.API.Models.Entities
+namespace StarAtlas.Domain.Entities
 {
     public class CelestialBody
     {

--- a/P2_Assignments/StarAtlas.Domain/Entities/Observation.cs
+++ b/P2_Assignments/StarAtlas.Domain/Entities/Observation.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace StarAtlas.API.Models.Entities
+namespace StarAtlas.Domain.Entities
 {
     public class Observation
     {

--- a/P2_Assignments/StarAtlas.Domain/StarAtlas.Domain.csproj
+++ b/P2_Assignments/StarAtlas.Domain/StarAtlas.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/P2_Assignments/StarAtlas.Infrastructure/Repositories/BodyTypeRepository.cs
+++ b/P2_Assignments/StarAtlas.Infrastructure/Repositories/BodyTypeRepository.cs
@@ -1,0 +1,13 @@
+﻿using StarAtlas.Domain.Entities;
+using StarAtlas.Persistence.Context;
+
+namespace StarAtlas.Infrastructure.Repositories
+{
+    public class BodyTypeRepository : GenericRepository<BodyType>
+    {
+        public BodyTypeRepository(StarAtlasContext context) : base(context)
+        {
+        }
+
+    }
+}

--- a/P2_Assignments/StarAtlas.Infrastructure/Repositories/CelestialBodyRepository.cs
+++ b/P2_Assignments/StarAtlas.Infrastructure/Repositories/CelestialBodyRepository.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore;
+using StarAtlas.Domain.Entities;
+using StarAtlas.Persistence.Context;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StarAtlas.Infrastructure.Repositories
+{
+    public class CelestialBodyRepository : GenericRepository<CelestialBody>
+    {
+        public CelestialBodyRepository(StarAtlasContext context) : base(context)
+        {
+        }
+
+        public async Task<IEnumerable<CelestialBody>> GetAllWithTypesAsync()
+        {
+            return await _context.CelestialBodies
+                                 .Include(c => c.BodyType)
+                                 .ToListAsync();
+        }
+
+        public async Task<CelestialBody?> GetByIdWithTypeAsync(int id)
+        {
+            return await _context.CelestialBodies
+                                 .Include(c => c.BodyType)
+                                 .FirstOrDefaultAsync(b => b.Id == id);
+        }
+    }
+}

--- a/P2_Assignments/StarAtlas.Infrastructure/Repositories/GenericRepository.cs
+++ b/P2_Assignments/StarAtlas.Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore;
+using StarAtlas.Persistence.Context;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace StarAtlas.Infrastructure.Repositories
+{
+    public class GenericRepository<T> where T : class
+    {
+        protected readonly StarAtlasContext _context;
+        protected readonly DbSet<T> _dbSet;
+
+        public GenericRepository(StarAtlasContext context)
+        {
+            _context = context;
+            _dbSet = context.Set<T>();
+        }
+
+        public async Task<IEnumerable<T>> GetAllAsync()
+        {
+            return await _dbSet.ToListAsync();
+        }
+
+        public async Task<T?> GetByIdAsync(int id)
+        {
+            return await _dbSet.FindAsync(id);
+        }
+
+        public async Task AddAsync(T entity)
+        {
+            await _dbSet.AddAsync(entity);
+        }
+
+        
+        public void Update(T entity)
+        {
+            _dbSet.Update(entity);
+        }
+
+        public void Delete(T entity)
+        {
+            _dbSet.Remove(entity);
+        }
+    }
+}

--- a/P2_Assignments/StarAtlas.Infrastructure/Repositories/ObservationRepository.cs
+++ b/P2_Assignments/StarAtlas.Infrastructure/Repositories/ObservationRepository.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore;
+using StarAtlas.Domain.Entities;
+using StarAtlas.Persistence.Context;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StarAtlas.Infrastructure.Repositories
+{
+    public class ObservationRepository : GenericRepository<Observation>
+    {
+        public ObservationRepository(StarAtlasContext context) : base(context)
+        {
+        }
+
+        public async Task<IEnumerable<Observation>> GetObservationsByStarAsync(int celestialBodyId)
+        {
+            return await _context.Observations
+                                 .Include(o => o.CelestialBody)
+                                 .Where(o => o.CelestialBodyId == celestialBodyId)
+                                 .OrderByDescending(o => o.ObservationDate)
+                                 .ToListAsync();
+        }
+    }
+}

--- a/P2_Assignments/StarAtlas.Infrastructure/Repositories/UnitOfWork.cs
+++ b/P2_Assignments/StarAtlas.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,0 +1,36 @@
+﻿using StarAtlas.Domain.Entities;
+using StarAtlas.Persistence.Context;
+using System.Threading.Tasks;
+
+namespace StarAtlas.Infrastructure.Repositories
+{
+    public class UnitOfWork
+    {
+        private readonly StarAtlasContext _context;
+
+        public CelestialBodyRepository CelestialBodyRepository { get; set; }
+        public ObservationRepository ObservationRepository { get; set; }
+        public BodyTypeRepository BodyTypeRepository { get; set; } 
+
+        public UnitOfWork(
+            StarAtlasContext context,
+            CelestialBodyRepository celestialBodyRepository,
+            ObservationRepository observationRepository,
+            BodyTypeRepository bodyTypeRepository) 
+        {
+            this._context = context;
+            this.CelestialBodyRepository = celestialBodyRepository;
+            this.ObservationRepository = observationRepository;
+            this.BodyTypeRepository = bodyTypeRepository;
+        }
+
+        public async Task<int> CompleteAsync()
+        {
+            return await _context.SaveChangesAsync();
+        }
+
+        public async Task BeginTransactionAsync() => await _context.Database.BeginTransactionAsync();
+        public async Task CommitTransactionAsync() => await _context.Database.CommitTransactionAsync();
+        public async Task RollbackTransactionAsync() => await _context.Database.RollbackTransactionAsync();
+    }
+}

--- a/P2_Assignments/StarAtlas.Infrastructure/StarAtlas.Infrastructure.csproj
+++ b/P2_Assignments/StarAtlas.Infrastructure/StarAtlas.Infrastructure.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StarAtlas.Domain\StarAtlas.Domain.csproj" />
+    <ProjectReference Include="..\StarAtlas.Persistence\StarAtlas.Persistence.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/P2_Assignments/StarAtlas.Persistence/Context/StarAtlasContext.cs
+++ b/P2_Assignments/StarAtlas.Persistence/Context/StarAtlasContext.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using StarAtlas.API.Models.Entities; 
+using StarAtlas.Domain.Entities;
 
-namespace StarAtlas.API.Data
+namespace StarAtlas.Persistence.Context
 {
     public class StarAtlasContext : DbContext
     {

--- a/P2_Assignments/StarAtlas.Persistence/Migrations/20260312155259_InitialCreate.Designer.cs
+++ b/P2_Assignments/StarAtlas.Persistence/Migrations/20260312155259_InitialCreate.Designer.cs
@@ -3,26 +3,29 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StarAtlas.API.Data;
+using StarAtlas.Persistence.Context;
 
 #nullable disable
 
-namespace StarAtlas.API.Migrations
+namespace StarAtlas.Persistence.Migrations
 {
     [DbContext(typeof(StarAtlasContext))]
-    partial class StarAtlasContextModelSnapshot : ModelSnapshot
+    [Migration("20260312155259_InitialCreate")]
+    partial class InitialCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.2")
+                .HasAnnotation("ProductVersion", "10.0.4")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.BodyType", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.BodyType", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -39,7 +42,7 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("BodyTypes");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.CelestialBody", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.CelestialBody", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -70,7 +73,7 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("CelestialBodies");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.Observation", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.Observation", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -98,9 +101,9 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("Observations");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.CelestialBody", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.CelestialBody", b =>
                 {
-                    b.HasOne("StarAtlas.API.Models.Entities.BodyType", "BodyType")
+                    b.HasOne("StarAtlas.Domain.Entities.BodyType", "BodyType")
                         .WithMany()
                         .HasForeignKey("BodyTypeId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -109,9 +112,9 @@ namespace StarAtlas.API.Migrations
                     b.Navigation("BodyType");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.Observation", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.Observation", b =>
                 {
-                    b.HasOne("StarAtlas.API.Models.Entities.CelestialBody", "CelestialBody")
+                    b.HasOne("StarAtlas.Domain.Entities.CelestialBody", "CelestialBody")
                         .WithMany()
                         .HasForeignKey("CelestialBodyId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/P2_Assignments/StarAtlas.Persistence/Migrations/20260312155259_InitialCreate.cs
+++ b/P2_Assignments/StarAtlas.Persistence/Migrations/20260312155259_InitialCreate.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace StarAtlas.API.Migrations
+namespace StarAtlas.Persistence.Migrations
 {
     /// <inheritdoc />
     public partial class InitialCreate : Migration

--- a/P2_Assignments/StarAtlas.Persistence/Migrations/StarAtlasContextModelSnapshot.cs
+++ b/P2_Assignments/StarAtlas.Persistence/Migrations/StarAtlasContextModelSnapshot.cs
@@ -3,29 +3,26 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StarAtlas.API.Data;
+using StarAtlas.Persistence.Context;
 
 #nullable disable
 
-namespace StarAtlas.API.Migrations
+namespace StarAtlas.Persistence.Migrations
 {
     [DbContext(typeof(StarAtlasContext))]
-    [Migration("20260209215507_InitialCreate")]
-    partial class InitialCreate
+    partial class StarAtlasContextModelSnapshot : ModelSnapshot
     {
-        /// <inheritdoc />
-        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.2")
+                .HasAnnotation("ProductVersion", "10.0.4")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.BodyType", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.BodyType", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -42,7 +39,7 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("BodyTypes");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.CelestialBody", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.CelestialBody", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -73,7 +70,7 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("CelestialBodies");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.Observation", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.Observation", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -101,9 +98,9 @@ namespace StarAtlas.API.Migrations
                     b.ToTable("Observations");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.CelestialBody", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.CelestialBody", b =>
                 {
-                    b.HasOne("StarAtlas.API.Models.Entities.BodyType", "BodyType")
+                    b.HasOne("StarAtlas.Domain.Entities.BodyType", "BodyType")
                         .WithMany()
                         .HasForeignKey("BodyTypeId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -112,9 +109,9 @@ namespace StarAtlas.API.Migrations
                     b.Navigation("BodyType");
                 });
 
-            modelBuilder.Entity("StarAtlas.API.Models.Entities.Observation", b =>
+            modelBuilder.Entity("StarAtlas.Domain.Entities.Observation", b =>
                 {
-                    b.HasOne("StarAtlas.API.Models.Entities.CelestialBody", "CelestialBody")
+                    b.HasOne("StarAtlas.Domain.Entities.CelestialBody", "CelestialBody")
                         .WithMany()
                         .HasForeignKey("CelestialBodyId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/P2_Assignments/StarAtlas.Persistence/StarAtlas.Persistence.csproj
+++ b/P2_Assignments/StarAtlas.Persistence/StarAtlas.Persistence.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StarAtlas.Domain\StarAtlas.Domain.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
refactor: implement layered architecture and repository pattern

- Extract domain entities to `StarAtlas.Domain` class library.
- Move `StarAtlasContext` and Entity Framework configurations to `StarAtlas.Persistence`.
- Implement `GenericRepository<T>` for base data access operations.
- Create specific repositories (`CelestialBodyRepository`, `ObservationRepository`, `BodyTypeRepository`) in `StarAtlas.Infrastructure`.
- Implement the `UnitOfWork` pattern to centralize repository access and manage DbContext saves.
- Refactor all controllers (`BodyTypes`, `CelestialBodies`, `Observations`) to consume data via `UnitOfWork` instead of direct DbContext access.